### PR TITLE
Add multipart boundary check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ install:
 language: php
 
 php:
-    - 5.3
     - 5.4
     - 5.5
     - 5.6
     - 7.0
+    - 7.2
 
 script:
     - mkdir -p build/logs

--- a/src/MessageParser.php
+++ b/src/MessageParser.php
@@ -114,7 +114,7 @@ class MessageParser implements MessageParserInterface
                     $part = $part->withPart($sub);
                 }
             } else {
-                return $part->withContents($this->parseContent($lines));
+                return $part->withContents($this->parseContent($lines, $boundary));
             }
         }
         return $part;

--- a/src/MessageParser.php
+++ b/src/MessageParser.php
@@ -57,7 +57,6 @@ class MessageParser implements MessageParserInterface
             if (empty($line)) {
                 break;
             }
-			//echo "LINE: $line...";
             if (preg_match(self::REGEX_HEADER_LINE, $line, $matches)) {
                 while ($lines->valid()) {
                     $lines->next();
@@ -129,7 +128,7 @@ class MessageParser implements MessageParserInterface
         while ($lines->valid()) {
             $line = $lines->current();
             $trimmed = trim($line);
-            if ($trimmed === "--$boundary" || $trimmed === "--$boundary--")
+            if ($boundary && ($trimmed === "--$boundary" || $trimmed === "--$boundary--"))
                 break;
             else
                 $contents[] = $line;


### PR DESCRIPTION
To correctly parse message parts, when matching the boundary expression it should consider the actual boundary, avoind potential matches with fake boundaries